### PR TITLE
Add null defaults to NoAnalytics provider

### DIFF
--- a/src/Ipunkt/LaravelAnalytics/Providers/NoAnalytics.php
+++ b/src/Ipunkt/LaravelAnalytics/Providers/NoAnalytics.php
@@ -30,7 +30,7 @@ class NoAnalytics implements AnalyticsProviderInterface
 	 *
 	 * @return void
 	 */
-	public function trackPage($page, $title, $hittype)
+	public function trackPage($page = null, $title = null, $hittype = null)
 	{
 	}
 
@@ -44,7 +44,7 @@ class NoAnalytics implements AnalyticsProviderInterface
 	 *
 	 * @return void
 	 */
-	public function trackEvent($category, $action, $label, $value)
+	public function trackEvent($category, $action, $label = null, $value = null)
 	{
 	}
 


### PR DESCRIPTION
Fixes an issue where a missing argument exception is thrown if a value
is not passed while using the NoAnalytics provider.