### PR TITLE
Add tracker name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Then edit `analytics.php` in `config` to your needs. We do config merge in the s
 <dl>
 <dt>tracking_id</dt><dd>Tracking ID</dd>
 <dt>tracking_domain</dt><dd>Tracking domain, unset or set to "<code>auto</code>" for automatic fallback</dd>
+<dt>tracker_name</dt><dd>Tracker name</dd>
 <dt>display_features</dt><dd>enabling the display features plugin, possible values: <code>(true|false)</code></dd>
 <dt>anonymize_ip</dt><dd>anonymize users ip, possible values: <code>(true|false)</code></dd>
 <dt>auto_track</dt><dd>auto tracking current pageview, possible values: <code>(true|false)</code></dd>

--- a/src/Ipunkt/LaravelAnalytics/Providers/GoogleAnalytics.php
+++ b/src/Ipunkt/LaravelAnalytics/Providers/GoogleAnalytics.php
@@ -32,6 +32,13 @@ class GoogleAnalytics implements AnalyticsProviderInterface
     private $trackingDomain;
 
     /**
+     * tracker name
+     *
+     * @var string
+     */
+    private $trackerName;
+
+    /**
      * display features plugin enabled or disabled
      *
      * @var bool
@@ -126,6 +133,7 @@ class GoogleAnalytics implements AnalyticsProviderInterface
     {
         $this->trackingId = array_get($options, 'tracking_id');
         $this->trackingDomain = array_get($options, 'tracking_domain', 'auto');
+        $this->trackerName = array_get($options, 'tracker_name', 't0');
         $this->displayFeatures = array_get($options, 'display_features', false);
         $this->anonymizeIp = array_get($options, 'anonymize_ip', false);
         $this->autoTrack = array_get($options, 'auto_track', false);
@@ -403,9 +411,9 @@ class GoogleAnalytics implements AnalyticsProviderInterface
             : sprintf(", {'userId': '%s'}", $this->userId);
 
         if ($this->debug || App::environment('local')) {
-            $script[] = "ga('create', '{$this->trackingId}', { 'cookieDomain': 'none' }{$trackingUserId});";
+            $script[] = "ga('create', '{$this->trackingId}', { 'cookieDomain': 'none' }, '{$this->trackerName}'{$trackingUserId});";
         } else {
-            $script[] = "ga('create', '{$this->trackingId}', '{$this->trackingDomain}'{$trackingUserId});";
+            $script[] = "ga('create', '{$this->trackingId}', '{$this->trackingDomain}', '{$this->trackerName}'{$trackingUserId});";
         }
 
         if ($this->ecommerceTracking) {

--- a/src/config/analytics.php
+++ b/src/config/analytics.php
@@ -33,10 +33,10 @@ return [
 			 */
 			'tracking_domain' => 'auto',
 
-            /**
-             * Tracker Name
-             */
-            'tracker_name' => 't0',
+			/**
+			 * Tracker Name
+			 */
+			'tracker_name' => 't0',
 
 			/**
 			 * enabling the display feature plugin

--- a/src/config/analytics.php
+++ b/src/config/analytics.php
@@ -33,6 +33,11 @@ return [
 			 */
 			'tracking_domain' => 'auto',
 
+            /**
+             * Tracker Name
+             */
+            'tracker_name' => 't0',
+
 			/**
 			 * enabling the display feature plugin
 			 */


### PR DESCRIPTION
This PR adds the option of setting a tracker name, as described in the following links:

- https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference#create
- https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#name