### PR TITLE
Add GA config env vars, allow cookieDomain tracking from local env

### DIFF
--- a/src/Ipunkt/LaravelAnalytics/Providers/GoogleAnalytics.php
+++ b/src/Ipunkt/LaravelAnalytics/Providers/GoogleAnalytics.php
@@ -410,7 +410,7 @@ class GoogleAnalytics implements AnalyticsProviderInterface
             ? ''
             : sprintf(", {'userId': '%s'}", $this->userId);
 
-        if ($this->debug || App::environment('local')) {
+        if ($this->debug) {
             $script[] = "ga('create', '{$this->trackingId}', { 'cookieDomain': 'none' }, '{$this->trackerName}'{$trackingUserId});";
         } else {
             $script[] = "ga('create', '{$this->trackingId}', '{$this->trackingDomain}', '{$this->trackerName}'{$trackingUserId});";

--- a/src/config/analytics.php
+++ b/src/config/analytics.php
@@ -27,7 +27,7 @@ return [
 			/**
 			 * Tracking ID
 			 */
-			'tracking_id' => env('ANALYTICS_TRACKING_ID'),
+			'tracking_id' => env('ANALYTICS_TRACKING_ID', 'UA-XXXXXXXX-1'),
 
 			/**
 			 * Tracking Domain

--- a/src/config/analytics.php
+++ b/src/config/analytics.php
@@ -59,7 +59,7 @@ return [
 			/**
 			 * Enable the debugging version of Google Analytics
 			 */
-			'debug' => env('ANALYTIS_DEBUG', env('APP_ENV') === 'local'),
+			'debug' => env('ANALYTICS_DEBUG', env('APP_ENV') === 'local'),
 		]
 
 	],

--- a/src/config/analytics.php
+++ b/src/config/analytics.php
@@ -16,6 +16,7 @@ return [
 		 * The Google Analytics provider supports the following properties:
 		 * - tracking_id (string)
 		 * - tracking_domain (string:auto) - default will be 'auto' if config property not exists
+		 * - tracker_name (string:t0) - default will be 't0' if config property not exists
 		 * - display_features (bool) - default will be false if no config property exists
 		 * - anonymize_ip (bool) - default will be false if no config property exists
 		 * - auto_track (bool) - default will be false if no config property exists

--- a/src/config/analytics.php
+++ b/src/config/analytics.php
@@ -27,39 +27,39 @@ return [
 			/**
 			 * Tracking ID
 			 */
-			'tracking_id' => env('ANALYTICS_TRACKING_ID' ,'UA-XXXXXXXX-1'),
+			'tracking_id' => env('ANALYTICS_TRACKING_ID'),
 
 			/**
 			 * Tracking Domain
 			 */
-			'tracking_domain' => 'auto',
+			'tracking_domain' => env('ANALYTICS_TRACKING_DOMAIN', 'auto'),
 
 			/**
 			 * Tracker Name
 			 */
-			'tracker_name' => 't0',
+			'tracker_name' => env('ANALYTICS_TRACKER_NAME', 't0'),
 
 			/**
 			 * enabling the display feature plugin
 			 */
-			'display_features' => false,
+			'display_features' => env('ANALYTICS_DISPLAY_FEATURES', false),
 
 			/**
 			 * Use ip anonymized
 			 */
-			'anonymize_ip' => true,
+			'anonymize_ip' => env('ANALYTICS_ANONYMIZE_IP', true),
 
 			/**
 			 * Auto tracking pageview: ga('send', 'pageview');
 			 * If false, you have to do it manually for each request
 			 * Or you can use Analytics::disableAutoTracking(), Analytics::enableAutoTracking()
 			 */
-			'auto_track' => true,
+			'auto_track' => env('ANALYTICS_AUTO_TRACK', true),
 
 			/**
-			 * Enable the debugging version of the
+			 * Enable the debugging version of Google Analytics
 			 */
-			'debug' => false,
+			'debug' => env('ANALYTIS_DEBUG', env('APP_ENV') !== 'local'),
 		]
 
 	],

--- a/src/config/analytics.php
+++ b/src/config/analytics.php
@@ -59,7 +59,7 @@ return [
 			/**
 			 * Enable the debugging version of Google Analytics
 			 */
-			'debug' => env('ANALYTIS_DEBUG', env('APP_ENV') !== 'local'),
+			'debug' => env('ANALYTIS_DEBUG', env('APP_ENV') === 'local'),
 		]
 
 	],


### PR DESCRIPTION
This PR changes the following things:

Add optional env() vars for the remaining Google Analytics config variables.

Allow having cookieDomain: auto (or anything else than none) on Laravel app env 'local'; I particularly needed this for making userId work on a local env'd site.

This works in conjunction with the first change by having an ANALYTICS_DEBUG env var which overrides the `App::environment('local')` check. By default it still enables debug mode on local by having `env('APP_ENV') === 'local'` as default value on said ANALYTICS_DEBUG env.

Add missing doc entry to config > configurations > GoogleAnalytics for a change from my earlier PR.

~~~I also removed the default value from the ANALYTICS_TRACKING_ID env, since you always need one when using Google Analytics. Feel free to revert this (or any other) if preferred.~~~ This broke application tests. I reverted it.

You might want to update the README.me with these changes. Or tell me what needs doing and I'll gladly add it to the PR.