### PR TITLE
Allow extension by making members protected

### DIFF
--- a/src/Ipunkt/LaravelAnalytics/Contracts/AnalyticsProviderInterface.php
+++ b/src/Ipunkt/LaravelAnalytics/Contracts/AnalyticsProviderInterface.php
@@ -213,6 +213,15 @@ interface AnalyticsProviderInterface
      */
     public function setCustom($dimension, $value = null);
 
+	/**
+	 * set a custom tracking ID (the UA-XXXXXXXX-1 code)
+	 *
+	 * @param string $trackingId
+	 *
+	 * @return AnalyticsProviderInterface
+	 */
+    public function setTrackingId($trackingId);
+
     /**
      * enables Content Security Polity and sets nonce
      *

--- a/src/Ipunkt/LaravelAnalytics/Providers/GoogleAnalytics.php
+++ b/src/Ipunkt/LaravelAnalytics/Providers/GoogleAnalytics.php
@@ -22,7 +22,7 @@ class GoogleAnalytics implements AnalyticsProviderInterface
      *
      * @var string
      */
-    private $trackingId;
+    protected $trackingId;
 
     /**
      * tracking domain

--- a/src/Ipunkt/LaravelAnalytics/Providers/GoogleAnalytics.php
+++ b/src/Ipunkt/LaravelAnalytics/Providers/GoogleAnalytics.php
@@ -22,7 +22,7 @@ class GoogleAnalytics implements AnalyticsProviderInterface
      *
      * @var string
      */
-    protected $trackingId;
+    private $trackingId;
 
     /**
      * tracking domain
@@ -733,4 +733,16 @@ class GoogleAnalytics implements AnalyticsProviderInterface
             ? '</script>'
             : '';
     }
+
+	/**
+	 * set a custom tracking ID (the UA-XXXXXXXX-1 code)
+	 *
+	 * @param string $trackingId
+	 *
+	 * @return AnalyticsProviderInterface
+	 */
+	public function setTrackingId( $trackingId ) {
+		$this->trackingId = $trackingId;
+		return $this;
+	}
 }

--- a/src/Ipunkt/LaravelAnalytics/Providers/NoAnalytics.php
+++ b/src/Ipunkt/LaravelAnalytics/Providers/NoAnalytics.php
@@ -306,4 +306,15 @@ class NoAnalytics implements AnalyticsProviderInterface
     {
         return null;
     }
+
+	/**
+	 * set a custom tracking ID (the UA-XXXXXXXX-1 code)
+	 *
+	 * @param string $trackingId
+	 *
+	 * @return AnalyticsProviderInterface
+	 */
+	public function setTrackingId( $trackingId ) {
+		return $this;
+	}
 }


### PR DESCRIPTION
This allows users to extend the GoogleAnalytics class and a custom tracking code (Per user configuration for example)